### PR TITLE
transfer dwi.json to output folder

### DIFF
--- a/mrtrix3_preproc.sh
+++ b/mrtrix3_preproc.sh
@@ -455,6 +455,12 @@ echo $lmaxs >> summary.txt
 
 cat summary.txt
 
+## transfer dwi.json to output folder
+DIFF_JSON=`jq -r '.diff_json' config.json`
+if [ $DIFF_JSON != "null" ]; then
+    cp $DIFF_JSON output/dwi.json
+fi    
+
 echo "Cleaning up working directory..."
 rm -f *.mif
 rm -f *.b


### PR DESCRIPTION
transfer dwi.json (if exists) to output folder so that metadata will be transferred. WARNING: this PR would require also a change in the configuration of the App(s), which should map `diff_json` to the dwi.json input file.